### PR TITLE
Fix OTLP metric attribute usage

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,191 @@
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const meterName = "github.com/apache/iceberg-go"
+
+var (
+	initOnce sync.Once
+
+	hiveRequestDuration  metric.Float64Histogram
+	avroFetchDuration    metric.Float64Histogram
+	hdfsAccessDuration   metric.Float64Histogram
+	hdfsDataVolume       metric.Int64Counter
+	filteringDuration    metric.Float64Histogram
+	filteredDataVolume   metric.Int64Counter
+	scanResultDuration   metric.Float64Histogram
+	scanResultDataVolume metric.Int64Counter
+)
+
+func ensureMeter() {
+	initOnce.Do(func() {
+		m := otel.GetMeterProvider().Meter(meterName)
+
+		var err error
+
+		hiveRequestDuration, err = m.Float64Histogram(
+			"iceberg.catalog.hive.request.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Time spent performing calls to the Hive metastore."),
+		)
+		handle(err)
+
+		avroFetchDuration, err = m.Float64Histogram(
+			"iceberg.scan.metadata.fetch.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Time spent retrieving Avro-based metadata files such as manifest lists and manifests."),
+		)
+		handle(err)
+
+		hdfsAccessDuration, err = m.Float64Histogram(
+			"iceberg.scan.hdfs.access.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Time spent opening files from HDFS-compatible storage for scanning."),
+		)
+		handle(err)
+
+		hdfsDataVolume, err = m.Int64Counter(
+			"iceberg.scan.hdfs.data.volume",
+			metric.WithUnit("By"),
+			metric.WithDescription("Total bytes requested from HDFS-compatible storage during scanning."),
+		)
+		handle(err)
+
+		filteringDuration, err = m.Float64Histogram(
+			"iceberg.scan.filter.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Time spent applying delete files and row-level filters during scanning."),
+		)
+		handle(err)
+
+		filteredDataVolume, err = m.Int64Counter(
+			"iceberg.scan.filtered.data.volume",
+			metric.WithUnit("By"),
+			metric.WithDescription("Bytes of data that remain after filtering has been applied."),
+		)
+		handle(err)
+
+		scanResultDuration, err = m.Float64Histogram(
+			"iceberg.scan.result.duration",
+			metric.WithUnit("s"),
+			metric.WithDescription("Time spent materialising scan results for consumers."),
+		)
+		handle(err)
+
+		scanResultDataVolume, err = m.Int64Counter(
+			"iceberg.scan.result.data.volume",
+			metric.WithUnit("By"),
+			metric.WithDescription("Bytes transferred to the consumer as part of scan results."),
+		)
+		handle(err)
+	})
+}
+
+func handle(err error) {
+	if err != nil {
+		otel.Handle(err)
+	}
+}
+
+// RecordHiveRequest records the duration of a Hive metastore operation.
+func RecordHiveRequest(ctx context.Context, operation string, d time.Duration) {
+	ensureMeter()
+	if hiveRequestDuration == nil {
+		return
+	}
+	opts := []metric.RecordOption{}
+	if operation != "" {
+		opts = append(opts, metric.WithAttributes(attribute.String("operation", operation)))
+	}
+	hiveRequestDuration.Record(ctx, d.Seconds(), opts...)
+}
+
+// RecordAvroFetch records how long it took to fetch an Avro metadata artifact.
+func RecordAvroFetch(ctx context.Context, kind string, d time.Duration) {
+	ensureMeter()
+	if avroFetchDuration == nil {
+		return
+	}
+	opts := []metric.RecordOption{}
+	if kind != "" {
+		opts = append(opts, metric.WithAttributes(attribute.String("kind", kind)))
+	}
+	avroFetchDuration.Record(ctx, d.Seconds(), opts...)
+}
+
+// RecordHDFSAccess records the time required to access an HDFS-backed file.
+func RecordHDFSAccess(ctx context.Context, format, content string, d time.Duration) {
+	ensureMeter()
+	if hdfsAccessDuration == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{}
+	if format != "" {
+		attrs = append(attrs, attribute.String("format", format))
+	}
+	if content != "" {
+		attrs = append(attrs, attribute.String("content", content))
+	}
+	if len(attrs) > 0 {
+		hdfsAccessDuration.Record(ctx, d.Seconds(), metric.WithAttributes(attrs...))
+	} else {
+		hdfsAccessDuration.Record(ctx, d.Seconds())
+	}
+}
+
+// AddHDFSVolume records the number of bytes requested from HDFS.
+func AddHDFSVolume(ctx context.Context, format, content string, bytes int64) {
+	ensureMeter()
+	if hdfsDataVolume == nil || bytes <= 0 {
+		return
+	}
+	attrs := []attribute.KeyValue{}
+	if format != "" {
+		attrs = append(attrs, attribute.String("format", format))
+	}
+	if content != "" {
+		attrs = append(attrs, attribute.String("content", content))
+	}
+	if len(attrs) > 0 {
+		hdfsDataVolume.Add(ctx, bytes, metric.WithAttributes(attrs...))
+	} else {
+		hdfsDataVolume.Add(ctx, bytes)
+	}
+}
+
+// RecordFilteringTime records the duration spent applying filtering steps.
+func RecordFilteringTime(ctx context.Context, d time.Duration) {
+	ensureMeter()
+	if filteringDuration == nil {
+		return
+	}
+	filteringDuration.Record(ctx, d.Seconds())
+}
+
+// AddFilteredVolume records the volume of data that remains after filtering.
+func AddFilteredVolume(ctx context.Context, bytes int64) {
+	ensureMeter()
+	if filteredDataVolume == nil || bytes <= 0 {
+		return
+	}
+	filteredDataVolume.Add(ctx, bytes)
+}
+
+// RecordScanResult records both the duration and resulting bytes of a completed scan.
+func RecordScanResult(ctx context.Context, d time.Duration, bytes int64) {
+	ensureMeter()
+	if scanResultDuration != nil {
+		scanResultDuration.Record(ctx, d.Seconds())
+	}
+	if scanResultDataVolume != nil && bytes > 0 {
+		scanResultDataVolume.Add(ctx, bytes)
+	}
+}

--- a/table/arrow_scanner.go
+++ b/table/arrow_scanner.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -31,6 +32,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/metrics"
 	"github.com/apache/iceberg-go/table/internal"
 	"github.com/apache/iceberg-go/table/substrait"
 	"github.com/substrait-io/substrait-go/v3/expr"
@@ -45,6 +47,19 @@ type (
 	positionDeletes   = []*arrow.Chunked
 	perFilePosDeletes = map[string]positionDeletes
 )
+
+func recordSize(rec arrow.Record) int64 {
+	if rec == nil {
+		return 0
+	}
+
+	var total int64
+	for i := 0; i < rec.NumCols(); i++ {
+		total += int64(rec.Column(i).Data().SizeInBytes())
+	}
+
+	return total
+}
 
 func readAllDeleteFiles(ctx context.Context, fs iceio.IO, tasks []FileScanTask, concurrency int) (perFilePosDeletes, error) {
 	var (
@@ -326,7 +341,8 @@ func (as *arrowScan) processRecords(
 	fileSchema *iceberg.Schema,
 	rdr internal.FileReader,
 	columns []int,
-	pipeline []recProcessFn,
+	filters []recProcessFn,
+	projector recProcessFn,
 	out chan<- enumeratedRecord,
 ) (err error) {
 	var (
@@ -349,8 +365,10 @@ func (as *arrowScan) processRecords(
 	defer recRdr.Release()
 
 	var (
-		idx  int
-		prev arrow.Record
+		idx            int
+		prev           arrow.Record
+		filterDuration time.Duration
+		filteredBytes  int64
 	)
 
 	for recRdr.Next() {
@@ -364,12 +382,25 @@ func (as *arrowScan) processRecords(
 		prev = recRdr.Record()
 		prev.Retain()
 
-		for _, f := range pipeline {
-			prev, err = f(prev)
+		if len(filters) > 0 {
+			start := time.Now()
+			for _, f := range filters {
+				prev, err = f(prev)
+				if err != nil {
+					return err
+				}
+			}
+			filterDuration += time.Since(start)
+		}
+
+		if projector != nil {
+			prev, err = projector(prev)
 			if err != nil {
 				return err
 			}
 		}
+
+		filteredBytes += recordSize(prev)
 	}
 
 	if prev != nil {
@@ -380,6 +411,13 @@ func (as *arrowScan) processRecords(
 
 	if recRdr.Err() != nil && recRdr.Err() != io.EOF {
 		err = recRdr.Err()
+	}
+
+	if filterDuration > 0 {
+		metrics.RecordFilteringTime(ctx, filterDuration)
+	}
+	if filteredBytes > 0 {
+		metrics.AddFilteredVolume(ctx, filteredBytes)
 	}
 
 	return err
@@ -406,7 +444,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	}
 	defer rdr.Close()
 
-	pipeline := make([]recProcessFn, 0, 2)
+	filters := make([]recProcessFn, 0, 2)
 	if len(positionalDeletes) > 0 {
 		deletes := set[int64]{}
 		for _, chunk := range positionalDeletes {
@@ -417,7 +455,7 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 			}
 		}
 
-		pipeline = append(pipeline, processPositionalDeletes(ctx, deletes))
+		filters = append(filters, processPositionalDeletes(ctx, deletes))
 	}
 
 	filterFunc, dropFile, err = as.getRecordFilter(ctx, iceSchema)
@@ -439,16 +477,16 @@ func (as *arrowScan) recordsFromTask(ctx context.Context, task internal.Enumerat
 	}
 
 	if filterFunc != nil {
-		pipeline = append(pipeline, filterFunc)
+		filters = append(filters, filterFunc)
 	}
 
-	pipeline = append(pipeline, func(r arrow.Record) (arrow.Record, error) {
+	projector := func(r arrow.Record) (arrow.Record, error) {
 		defer r.Release()
 
 		return ToRequestedSchema(ctx, as.projectedSchema, iceSchema, r, false, false, as.useLargeTypes)
-	})
+	}
 
-	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, pipeline, out)
+	err = as.processRecords(ctx, task, iceSchema, rdr, colIndices, filters, projector, out)
 
 	return
 }


### PR DESCRIPTION
## Summary
- wrap metric attribute key-values with metric.WithAttributes so histogram and counter calls compile
- avoid attaching empty attribute sets by only passing WithAttributes when labels are present

## Testing
- go test ./... (aborted: hangs in current environment)


------
https://chatgpt.com/codex/tasks/task_e_68df9d234c00832f908f2fa2414b25a3