### PR TITLE
Add Hive catalog commit support

### DIFF
--- a/catalog/hive/hive_mock_test.go
+++ b/catalog/hive/hive_mock_test.go
@@ -78,8 +78,12 @@ func (m *mockMetastore) DropTable(ctx context.Context, db, tbl string, _ bool) e
 }
 
 func (m *mockMetastore) AlterTable(ctx context.Context, db, tbl string, newTable *hms.Table) error {
-	m.tables[newTable.DbName+"."+newTable.TableName] = newTable
-	delete(m.tables, db+"."+tbl)
+	oldKey := db + "." + tbl
+	newKey := newTable.DbName + "." + newTable.TableName
+	if oldKey != newKey {
+		delete(m.tables, oldKey)
+	}
+	m.tables[newKey] = newTable
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- implement `CommitTable` for the Hive catalog to stage metadata updates and write new metadata locations
- add a `CheckTableExists` implementation that verifies Iceberg metadata presence
- cover Hive commit and existence flows with mock-based tests

## Testing
- go test ./... *(fails due to missing external telemetry and stash dependencies in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef596293c832fada61ef793933e2a)